### PR TITLE
Fix the issue with the 'abstract[*]' environment command and the disp…

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -17,6 +17,8 @@
 \usepackage{longtable}      %支持跨页的表格。
 \usepackage[justification=centering]{caption}
 % =================================
+\setmainfont{Times New Roman} % 设置英文字体为Times New Roman
+% =================================
 \setcitestyle{super} %角标格式右上
 % =================================
 % 定义所有的图片文件在 figures 子目录下

--- a/shouthesis.cls
+++ b/shouthesis.cls
@@ -460,7 +460,11 @@
 % 中文摘要环境
 % ============================
 \newenvironment{abstract}{
-
+    % =================================
+    % 修复摘要部分页眉页脚
+    \thispagestyle{plain}
+    \pagestyle{plain}
+    % =================================    
     \chapter*{\centering\heiti\zihao{3}\selectfont{}这里是中文标题}
 \vspace{1em}
     {\centering\heiti\zihao{3}\selectfont{}摘~~~~要\par}
@@ -482,7 +486,11 @@
 % ============================
 \newenvironment{abstract*}{
     %\chapter*{\centering\rmfamily\bfseries\zihao{3}\selectfont ABSTRACT}%
-
+    % =================================
+    % 修复摘要部分页眉页脚
+    \thispagestyle{plain}
+    \pagestyle{plain}
+    % ================================= 
     \chapter*{\centering\heiti\zihao{3}\selectfont{}\textbf{HERE IS THE EN TITLE}}
 \vspace{1em}
     {\centering\heiti\zihao{3}\selectfont{}ABSTRACT\par}


### PR DESCRIPTION
1. 修复了中英文摘要在跨页情况下页眉页脚丢失问题
2. 修复了生成文档中西文字体与《上海海洋大学研究生学位论文格式排版》西文字体Times New Roman显示不一致的情况